### PR TITLE
PEP8: Surround top-level functions with two blank lines.

### DIFF
--- a/application.py
+++ b/application.py
@@ -30,10 +30,12 @@ Session(app)
 # configure CS50 Library to use SQLite database
 db = SQL("sqlite:///finance.db")
 
+
 @app.route("/")
 @login_required
 def index():
     return apology("TODO")
+
 
 @app.route("/buy", methods=["GET", "POST"])
 @login_required
@@ -41,11 +43,13 @@ def buy():
     """Buy shares of stock."""
     return apology("TODO")
 
+
 @app.route("/history")
 @login_required
 def history():
     """Show history of transactions."""
     return apology("TODO")
+
 
 @app.route("/login", methods=["GET", "POST"])
 def login():
@@ -82,6 +86,7 @@ def login():
     else:
         return render_template("login.html")
 
+
 @app.route("/logout")
 def logout():
     """Log user out."""
@@ -92,16 +97,19 @@ def logout():
     # redirect user to login form
     return redirect(url_for("login"))
 
+
 @app.route("/quote", methods=["GET", "POST"])
 @login_required
 def quote():
     """Get stock quote."""
     return apology("TODO")
 
+
 @app.route("/register", methods=["GET", "POST"])
 def register():
     """Register user."""
     return apology("TODO")
+
 
 @app.route("/sell", methods=["GET", "POST"])
 @login_required

--- a/helpers.py
+++ b/helpers.py
@@ -4,6 +4,7 @@ import urllib.request
 from flask import redirect, render_template, request, session, url_for
 from functools import wraps
 
+
 def apology(top="", bottom=""):
     """Renders message as an apology to user."""
     def escape(s):
@@ -18,6 +19,7 @@ def apology(top="", bottom=""):
         return s
     return render_template("apology.html", top=escape(top), bottom=escape(bottom))
 
+
 def login_required(f):
     """
     Decorate routes to require login.
@@ -30,6 +32,7 @@ def login_required(f):
             return redirect(url_for("login", next=request.url))
         return f(*args, **kwargs)
     return decorated_function
+
 
 def lookup(symbol):
     """Look up quote for symbol."""
@@ -64,6 +67,7 @@ def lookup(symbol):
         "price": price,
         "symbol": row[0].upper()
     }
+
 
 def usd(value):
     """Formats value as USD."""


### PR DESCRIPTION
We should surround top-level functions with two blank lines per PEP8 (https://www.python.org/dev/peps/pep-0008/#blank-lines). They were originally only surrounded by one.